### PR TITLE
User can now install blocks and kits by referring to respective index

### DIFF
--- a/lib/commands/blocks.js
+++ b/lib/commands/blocks.js
@@ -37,37 +37,53 @@ function listBuildingBlocks(args, options, callback) {
 }
 
 function installBuildingBlock(args, options, callback) {
-  var name = args[0];
-  assertInstallableRepo(function(type) {
-    if(type === 'zip') {
-      downloadZipFile(name, function(err) {
-        if(err) {
-          console.log(err);
-        } else {
-          console.log('downloaded ' + name + '.zip');
-        }
-      });
-    } else {
-      installFiles(name, function(err, results) {
-        if(results && _.every(results)) {
-          console.log('Not found: ' + name)
-        } else {
-          async.parallel([updateAppSCSS.bind(null, name), updateConfigYml.bind(null, name)]
-          , function() {
-            console.log("installed ", name);
-            if(callback) {callback();}
-          });
-        }
+  fetchUrl('foundation.zurb.com', "/building-blocks/data/building-blocks.json", function(data) {
+    var name = args[0];
+    if (Number.isInteger(1*name)) {
+      var selection = 1*name;
+      var i = 0;
+      var kits = JSON.parse(data);
+      _.each(kits, function(value, key) {
+	i++;
+	if (selection === i) {
+	  name = key;
+	}
       });
     }
-  });
+
+    assertInstallableRepo(function(type) {
+      if(type === 'zip') {
+	downloadZipFile(name, function(err) {
+	  if(err) {
+	    console.log(err);
+	  } else {
+	    console.log('downloaded ' + name + '.zip');
+	  }
+	});
+      } else {
+	installFiles(name, function(err, results) {
+	  if(results && _.every(results)) {
+	    console.log('Not found: ' + name)
+	  } else {
+	    async.parallel([updateAppSCSS.bind(null, name), updateConfigYml.bind(null, name)]
+	      , function() {
+		console.log("installed ", name);
+		if(callback) {callback();}
+	      });
+	  }
+	});
+      }
+    });
+  }
+  )
 }
+
 
 function updateConfigYml(name, callback) {
   var doc         = fs.readFileSync('config.yml', 'utf8'),
-      jsString    = "src/assets/js/building-blocks/" + name + ".js",
-      appJsString = "src/assets/js/app.js",
-      lineNum = -1;
+    jsString    = "src/assets/js/building-blocks/" + name + ".js",
+    appJsString = "src/assets/js/app.js",
+    lineNum = -1;
 
   if(!fs.existsSync(jsString)) {
     if(callback) {callback();}
@@ -132,11 +148,11 @@ function installFiles(name, callback) {
     var path = '/building-blocks/files/building-blocks/' + name + '/' + filename;
     fs.mkdir(filetype.directory, function() {
       fetchUrl('foundation.zurb.com', path, function(file) {
-        if(file.length > 0) {
-          fs.writeFile(filetype.directory + filetype.prefix + filename, file,  cb);
-        } else {
-          cb(null, true);
-        }
+	if(file.length > 0) {
+	  fs.writeFile(filetype.directory + filetype.prefix + filename, file,  cb);
+	} else {
+	  cb(null, true);
+	}
       });
     });
   }, callback)

--- a/lib/commands/blocks.js
+++ b/lib/commands/blocks.js
@@ -44,46 +44,46 @@ function installBuildingBlock(args, options, callback) {
       var i = 0;
       var kits = JSON.parse(data);
       _.each(kits, function(value, key) {
-	i++;
-	if (selection === i) {
-	  name = key;
-	}
+	      i++;
+	      if (selection === i) {
+	        name = key;
+	      }
       });
     }
 
     assertInstallableRepo(function(type) {
       if(type === 'zip') {
-	downloadZipFile(name, function(err) {
-	  if(err) {
-	    console.log(err);
-	  } else {
-	    console.log('downloaded ' + name + '.zip');
-	  }
-	});
-      } else {
-	installFiles(name, function(err, results) {
-	  if(results && _.every(results)) {
-	    console.log('Not found: ' + name)
-	  } else {
-	    async.parallel([updateAppSCSS.bind(null, name), updateConfigYml.bind(null, name)]
-	      , function() {
-		console.log("installed ", name);
-		if(callback) {callback();}
+	      downloadZipFile(name, function(err) {
+	        if(err) {
+	          console.log(err);
+	        } else {
+	          console.log('downloaded ' + name + '.zip');
+	        }
 	      });
-	  }
-	});
+      } else {
+	      installFiles(name, function(err, results) {
+	        if(results && _.every(results)) {
+	          console.log('Not found: ' + name)
+	        } else {
+	          async.parallel([updateAppSCSS.bind(null, name), updateConfigYml.bind(null, name)]
+	                         , function() {
+		                         console.log("installed ", name);
+		                         if(callback) {callback();}
+	                         });
+	        }
+	      });
       }
     });
   }
-  )
+          )
 }
 
 
 function updateConfigYml(name, callback) {
   var doc         = fs.readFileSync('config.yml', 'utf8'),
-    jsString    = "src/assets/js/building-blocks/" + name + ".js",
-    appJsString = "src/assets/js/app.js",
-    lineNum = -1;
+      jsString    = "src/assets/js/building-blocks/" + name + ".js",
+      appJsString = "src/assets/js/app.js",
+      lineNum = -1;
 
   if(!fs.existsSync(jsString)) {
     if(callback) {callback();}
@@ -148,11 +148,11 @@ function installFiles(name, callback) {
     var path = '/building-blocks/files/building-blocks/' + name + '/' + filename;
     fs.mkdir(filetype.directory, function() {
       fetchUrl('foundation.zurb.com', path, function(file) {
-	if(file.length > 0) {
-	  fs.writeFile(filetype.directory + filetype.prefix + filename, file,  cb);
-	} else {
-	  cb(null, true);
-	}
+	      if(file.length > 0) {
+	        fs.writeFile(filetype.directory + filetype.prefix + filename, file,  cb);
+	      } else {
+	        cb(null, true);
+	      }
       });
     });
   }, callback)

--- a/lib/commands/kits.js
+++ b/lib/commands/kits.js
@@ -44,30 +44,43 @@ function getKitList(callback) {
 }
 
 function installKit(args, options, callback) {
-  var name = args[0];
-  assertInstallableRepo(function(type) {
-    if(type === 'zip') {
-      downloadZipFile(name, function() {
-        console.log('downloaded ' + name + '.zip');
-      });
-    } else {
-      getKitList(function(kits) {
-        if (!kits[name]) {
-          console.log('Could not find kit: ', name);
-          if(callback) {callback();}
-          return;
+  fetchUrl('foundation.zurb.com', "/building-blocks/data/kits.json", function(data) {
+    var name = args[0];
+    if (Number.isInteger(1*name)) {
+      var selection = 1*name;
+      var i = 0;
+      var kits = JSON.parse(data);
+      _.each(kits, function(value, key) {
+        i++;
+        if (selection === i) {
+          name = key;
         }
-        var blocks = kits[name].blocks;
-        async.eachSeries(blocks, function(block, cb) {
-          blockCommand(['install', block.datakey], {}, cb);
-        }, function() {
-          console.log("done installing kit: ", name);
-          if(callback) {callback();}
-        })
       });
     }
-  });
-}
+    assertInstallableRepo(function(type) {
+      if(type === 'zip') {
+        downloadZipFile(name, function() {
+          console.log('downloaded ' + name + '.zip');
+        });
+      } else {
+        getKitList(function(kits) {
+          if (!kits[name]) {
+            console.log('Could not find kit: ', name);
+            if(callback) {callback();}
+            return;
+          }
+          var blocks = kits[name].blocks;
+          async.eachSeries(blocks, function(block, cb) {
+            blockCommand(['install', block.datakey], {}, cb);
+          }, function() {
+            console.log("done installing kit: ", name);
+            if(callback) {callback();}
+          })
+        });
+      }
+    });
+  }
+  )};
 
 function downloadZipFile(name, callback) {
   var filename = name + '.zip';

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,15 @@
 # Foundation CLI
 
-This is the command-line interface for [Foundation](http://foundation.zurb.com) family of frameworks.. It downloads and installs blank templates in any of the three Foundation frameworks:
+This is the command-line interface for [Foundation](http://foundation.zurb.com) family of frameworks. It downloads and installs blank templates in any of the three Foundation frameworks:
 
 - [Foundation for Sites](http://foundation.zurb.com/sites), a framework for responsive websites.
 - [Foundation for Apps](http://foundation.zurb.com/apps), a framework for responsive web apps.
 - [Foundation for Emails](http://foundation.zurb.com/emails), a framework for responsive email.
+
+Additionally, the `foundation-cli` downloads and installs Foundation Building-Blocks and Kits.
+
+- [Foundation Building-Blocks](http://foundation.zurb.com/building-blocks/)
+- [Foundation Kits](http://foundation.zurb.com/building-blocks/kits.html)
 
 ## Requirements
 
@@ -48,6 +53,27 @@ Starts the setup process for a new Foundation project. The CLI will ask you whic
 ```bash
 foundation new
 ```
+
+### Blocks
+
+List available Building-Blocks or install one of your choice.
+
+```bash
+foundation blocks <list|install block>
+```
+
+Note:
+A Building-Block may be installed by referring to it by name -- e.g.: 'card-product-hover' -- or by its index number.
+
+
+### Kits
+
+List available Kits or install one of your choice. Kits comprise a set of Building-Blocks.
+
+```bash
+foundation kits <list|install kit>
+```
+
 
 ### Watch
 


### PR DESCRIPTION
This PR allows end-user to install a block/kit by simply referring to its respective index number. 

Index numbers are derived from alphabetic listing of keys in JSON manifests for blocks/kits.

Example implementation:
Given such a listing as this:
````bash
|18:09:58|ramos@Prometheus:[test]> node ../bin/foundation.js kits list
 1) blog: 13 blocks
 2) dashboard: 16 blocks
 3) ecommerce: 19 blocks
 4) marketing: 15 blocks
 5) mobile-app: 15 blocks
 6) news: 22 blocks
 7) portfolio: 11 blocks
 8) real-estate-travel: 13 blocks
````

One could install the "marketing" kit in the following way:
````bash
|18:10:13|ramos@Prometheus:[test]> node ../bin/foundation.js kits install 4
You don't appear to be in a ZURB stack project, so we can't automatically install building blocks
? Do you want to download as a zip file? Yes
downloaded marketing.zip
````
I will updated README in a moment.


