### PR TITLE
subcommand of blocks to search by name

### DIFF
--- a/lib/commands/blocks.js
+++ b/lib/commands/blocks.js
@@ -42,12 +42,16 @@ function searchBuildingBlocks(args, options, callback) {
     var query = args[0];
     term("Search results for '").cyan(query)("':\n")
     var blocks = JSON.parse(blocksJson);
+    var i =0;
     _.each(blocks, function(value, key) {
       if (key.indexOf(query) > -1) {
+        i++;
         var r = key.replace(query,term.cyan.str(query));
         term(" • ")(r)("\n")
       }
     })
+    if (i === 0)
+      term.red(" * no results * \n");
     if(callback) {callback()};
   })
 }

--- a/lib/commands/blocks.js
+++ b/lib/commands/blocks.js
@@ -9,7 +9,8 @@ var assertInstallableRepo = require('../util/assert-installable-repo');
 
 var subcommands = {
   list: listBuildingBlocks,
-  install: installBuildingBlock
+  install: installBuildingBlock,
+  search: searchBuildingBlocks
 };
 
 module.exports = function(args, options, callback) {
@@ -36,6 +37,22 @@ function listBuildingBlocks(args, options, callback) {
   });
 }
 
+function searchBuildingBlocks(args, options, callback) {
+  fetchUrl('foundation.zurb.com', '/building-blocks/data/building-blocks.json', function(blocksJson) {
+    var query = args[0];
+    term("Search results for '").cyan(query)("':\n")
+    var blocks = JSON.parse(blocksJson);
+    _.each(blocks, function(value, key) {
+      if (key.indexOf(query) > -1) {
+        var r = key.replace(query,term.cyan.str(query));
+        term(" • ")(r)("\n")
+      }
+    })
+    if(callback) {callback()};
+  })
+}
+
+
 function installBuildingBlock(args, options, callback) {
   var name = args[0];
   assertInstallableRepo(function(type) {
@@ -53,10 +70,10 @@ function installBuildingBlock(args, options, callback) {
           console.log('Not found: ' + name)
         } else {
           async.parallel([updateAppSCSS.bind(null, name), updateConfigYml.bind(null, name)]
-          , function() {
-            console.log("installed ", name);
-            if(callback) {callback();}
-          });
+            , function() {
+              console.log("installed ", name);
+              if(callback) {callback();}
+            });
         }
       });
     }
@@ -65,9 +82,9 @@ function installBuildingBlock(args, options, callback) {
 
 function updateConfigYml(name, callback) {
   var doc         = fs.readFileSync('config.yml', 'utf8'),
-      jsString    = "src/assets/js/building-blocks/" + name + ".js",
-      appJsString = "src/assets/js/app.js",
-      lineNum = -1;
+    jsString    = "src/assets/js/building-blocks/" + name + ".js",
+    appJsString = "src/assets/js/app.js",
+    lineNum = -1;
 
   if(!fs.existsSync(jsString)) {
     if(callback) {callback();}


### PR DESCRIPTION
As per #61, user can now search for a block by name. Search method returns a block name for partial string matches.

For example, `foundation blocks search article` yields this:
````bash
Search results for 'article':
 • simple-article-header
 • neat-article-container
 • large-article-header
 • flexible-article-images
 • featured-article-side-links
 • card-flex-article
 • article-row-section
 • article-card-hover
 • wide-article-link
````
EDIT:
👉 @kball 