### PR TITLE
Update fetch-url.js

### DIFF
--- a/lib/util/fetch-url.js
+++ b/lib/util/fetch-url.js
@@ -1,4 +1,4 @@
-var http = require('http');
+var http = require('https');
 
 module.exports = function fetchUrl(host, path, done) {
   var options = {
@@ -22,5 +22,5 @@ module.exports = function fetchUrl(host, path, done) {
       }
     });
   };
-  http.request(options, callback).end();
+  https.request(options, callback).end();
 }

--- a/lib/util/fetch-url.js
+++ b/lib/util/fetch-url.js
@@ -22,5 +22,5 @@ module.exports = function fetchUrl(host, path, done) {
       }
     });
   };
-  https.request(options, callback).end();
+  http.request(options, callback).end();
 }


### PR DESCRIPTION
The URL http://foundation.zurb.com redirects to https://foundation.zurb.com causing an error in the commands `foundation kits ...` and `foundation blocks ...`.
Requiring `https` fixes the issues, allowing users to list/install kits and blocks.