### PR TITLE
Update documentation about Foundation for Apps and Bower

### DIFF
--- a/lib/util/questions.js
+++ b/lib/util/questions.js
@@ -13,7 +13,7 @@ module.exports = function(options) {
       name: 'A website (Foundation for Sites)',
       value: 'sites'
     }, {
-      name: 'A web app (Foundation for Apps)',
+      name: 'A web app (Foundation for Apps) (deprecated - use Sites instead)',
       value: 'apps'
     }, {
       name: 'An email (Foundation for Emails)',

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # Foundation CLI
 
-This is the command-line interface for [Foundation](https://foundation.zurb.com) family of frameworks.. It downloads and installs blank templates in any of the three Foundation frameworks:
+This is the command-line interface for [Foundation](https://foundation.zurb.com) family of frameworks. It downloads and installs blank templates in any of the three Foundation frameworks:
 
-- [Foundation for Sites](https://foundation.zurb.com/sites), a framework for responsive websites.
-- [Foundation for Apps](https://foundation.zurb.com/apps), a framework for responsive web apps.
-- [Foundation for Emails](https://foundation.zurb.com/emails), a framework for responsive email.
+- [Foundation for Sites](https://foundation.zurb.com/sites), a framework for responsive websites
+- [Foundation for Apps](https://foundation.zurb.com/apps), a framework for responsive web apps ([deprecated](https://github.com/zurb/foundation-apps#deprecation-notice))
+- [Foundation for Emails](https://foundation.zurb.com/emails), a framework for responsive email
 
 ## Requirements
 
@@ -76,7 +76,7 @@ foundation build
 
 ### Update
 
-Updates your Bower packages, which includes Foundation. Run this command when you want to update an existing project to the newest version of Foundation.
+Updates your Bower packages, which includes Foundation. Run this command if you're using Bower instead of NPM or Yarn and you want to update an existing project to the newest version of Foundation.
 
 ```bash
 foundation update


### PR DESCRIPTION
Foundation for Apps is deprecated; update the documentation accordingly. (Would it be better to completely delete support for Foundation for Apps?)

Add a note that `foundation update` should only be used for Bower.  (If you'd prefer that I instead extend it to call Yarn or NPM, I can, but it seems better to leave that task to Yarn or NPM.)