### PR TITLE
using npm-force-resolutions to upgrade graceful-fs which fix the erro…

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,11 @@
     "url": "https://github.com/foundation/foundation-cli/issues"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "test": "node bin/foundation.js new"
+  },
+  "resolutions": {
+    "graceful-fs": "^4.2.4"
   },
   "preferGlobal": true,
   "engines": {


### PR DESCRIPTION
The CLI is broken after upgrade to node v12+. According to [this](https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node) answer, it is caused by the `graceful-fs` and I follow the suggestion to using `npm-force-resolutions` to force `graceful-fs` upgrade to `^4.2.4`. It is not a perfect solution IMO, but it works. I did not dive into the source to find which package that depends on `graceful-fs` and should be upgraded. So if you have any idea about upgrade `graceful-fs` in `package.json` dependency, please ignore this PR.

I did not add information about version and node version constrain. Please upgrade these and release a new version. Thanks.